### PR TITLE
Duplicate field uponedit

### DIFF
--- a/public/modules/forms/admin/controllers/admin-form.client.controller.js
+++ b/public/modules/forms/admin/controllers/admin-form.client.controller.js
@@ -133,15 +133,16 @@ angular.module('forms').controller('AdminFormController', ['$rootScope', '$windo
                     $rootScope.saveInProgress = true;
                 }
 
+
                 if (isDiffed) {
+
                     $scope.updatePromise = $http.put('/forms/' + $scope.myform._id, {changes: data})
                         .then(function (response) {
 
                             if (refreshAfterUpdate) $rootScope.myform = $scope.myform = response.data;
-                            // console.log(response.data);
+
                         }).catch(function (response) {
                             console.log('Error occured during form UPDATE.\n');
-                            // console.log(response.data);
                             err = response.data;
                         }).finally(function () {
                             // console.log('finished updating');
@@ -154,6 +155,7 @@ angular.module('forms').controller('AdminFormController', ['$rootScope', '$windo
                             }
                         });
                 } else {
+
                     var dataToSend = data;
                     if(dataToSend.analytics && dataToSend.analytics.visitors){
                         delete dataToSend.analytics.visitors;
@@ -169,10 +171,8 @@ angular.module('forms').controller('AdminFormController', ['$rootScope', '$windo
 
                         }).catch(function (response) {
                             console.log('Error occured during form UPDATE.\n');
-                            // console.log(response.data);
                             err = response.data;
                         }).finally(function () {
-                            // console.log('finished updating');
                             if (!updateImmediately) {
                                 $rootScope.saveInProgress = false;
                             }

--- a/public/modules/forms/admin/directives/edit-form.client.directive.js
+++ b/public/modules/forms/admin/directives/edit-form.client.directive.js
@@ -131,6 +131,15 @@ angular.module('forms').directive('editFormDirective', ['$rootScope', 'FormField
 
 							$scope.saveField = function(){
 
+								// Remove duplicate first
+								if (curr_field.globalId != undefined) {
+									for (var i = 0; i < $scope.myform.form_fields.length; i++) {
+										var field = $scope.myform.form_fields[i];
+										if (field.globalId == curr_field.globalId) {
+											$scope.myform.form_fields.splice(i, 1);
+										}
+									}
+								}
 								$scope.myform.form_fields.push(curr_field);
 								$scope.$parent.update(false, $scope.$parent.myform, false, true, function(){
 									$uibModalInstance.close();

--- a/public/modules/forms/admin/directives/edit-form.client.directive.js
+++ b/public/modules/forms/admin/directives/edit-form.client.directive.js
@@ -19,12 +19,12 @@ angular.module('forms').directive('editFormDirective', ['$rootScope', 'FormField
 				//Setup UI-Sortable
 				$scope.sortableOptions = {
 					appendTo: '.dropzone',
-					helper: 'clone',
+					helper: 'original',
 					forceHelperSize: true,
 					forcePlaceholderSize: true,
 					update: function(e, ui) {
-						$scope.update(false, $scope.myform, false, false, function(err){
-							if(!err) $scope.myform.form_fields.push(newField);
+						$scope.update(false, $scope.myform, false, true, function(err){
+							if(err) console.log(err);
 						});
 					},
 					start: function(e, ui) {

--- a/public/modules/forms/admin/directives/edit-form.client.directive.js
+++ b/public/modules/forms/admin/directives/edit-form.client.directive.js
@@ -131,16 +131,25 @@ angular.module('forms').directive('editFormDirective', ['$rootScope', 'FormField
 
 							$scope.saveField = function(){
 
+								// Have to insert back at same spot if it is an edit
+								var indexToInsert = -1;
+
 								// Remove duplicate first
 								if (curr_field.globalId != undefined) {
 									for (var i = 0; i < $scope.myform.form_fields.length; i++) {
 										var field = $scope.myform.form_fields[i];
 										if (field.globalId == curr_field.globalId) {
 											$scope.myform.form_fields.splice(i, 1);
+											indexToInsert = i;
 										}
 									}
 								}
-								$scope.myform.form_fields.push(curr_field);
+								if (indexToInsert >= 0) {
+									$scope.myform.form_fields.splice(indexToInsert, 0, curr_field);	
+								} else {
+									$scope.myform.form_fields.push(curr_field);	
+								}
+
 								$scope.$parent.update(false, $scope.$parent.myform, false, true, function(){
 									$uibModalInstance.close();
 								});

--- a/public/modules/forms/admin/views/directiveViews/form/edit-form.client.view.html
+++ b/public/modules/forms/admin/views/directiveViews/form/edit-form.client.view.html
@@ -556,7 +556,7 @@
         <div class="row">
             <div class="col-sm-12 col-md-10 dropzoneContainer">
 
-                <div class="panel-group dropzone" ui-sortable="sortableOptions">
+                <div class="panel-group dropzone" ui-sortable="sortableOptions" ng-model="myform.form_fields">
 
                     <div class="panel panel-default" ng-repeat="field in myform.form_fields"
 									 ng-if="!field.deletePreserved"


### PR DESCRIPTION
Fixed two of the following stories:

- On the Create tab, form fields are duplicated when user 1) edits a form field and clicks save, 2) rearranges form fields.

This is fixed by searching for old terms and replacing them in position.

- On the Create tab, order of form fields are not persisted after rearranging

This is fixed by defining `ng-model` in `ui-sortable`, changing `clone` type to `original` in sortable options, and tweaking some options in the `update` call.