### PR TITLE
temporarily remove logic jump in field edit pop-up

### DIFF
--- a/public/modules/forms/admin/views/directiveViews/form/edit-form.client.view.html
+++ b/public/modules/forms/admin/views/directiveViews/form/edit-form.client.view.html
@@ -379,6 +379,7 @@
 						</div>
 					</div>
 
+<!--
 					<div class="row">
 						<div class="col-md-4 col-xs-12 field-input">{{ 'LOGIC_JUMP' | translate }}</div>
 						<div class="col-md-8 col-xs-12 field-input">
@@ -471,6 +472,7 @@
 							</select>
 						</div>
 					</div>
+-->
 					<div class="modal-footer row">
 						<button type="submit" ng-click="saveField()" class="btn btn-signup btn-rounded">
 							{{ 'SAVE_FIELD' | translate }}


### PR DESCRIPTION
- commented out instead of removing the relevant code because we might
need it with some customisation in the future